### PR TITLE
Fix invalid android + arm integration test combo

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -19,18 +19,14 @@ steps:
     command: go version
     plugins:
       ${BUILDKITE_REPO}#${BUILDKITE_COMMIT}:
-        version: 1.10.2
+        version: 1.13.8
 
   - label: test cross compiling
     command: go build ./tests/helloworld
     plugins:
       ${BUILDKITE_REPO}#${BUILDKITE_COMMIT}:
-        version: 1.10.2
+        version: 1.13.8
         environment:
-          - GOOS=android
+          - GOOS=linux
           - GOARCH=arm
           - GOARM=7
-
-
-
-

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ steps:
   - command: go test ./...
     plugins:
       - golang#v2.0.0:
-          version: 1.10.2
+          version: 1.13.8
           import: github.com/buildkite/agent
 ```
 
@@ -26,7 +26,7 @@ steps:
   - command: go build .
     plugins:
       - golang#v2.0.0:
-          version: 1.10.2
+          version: 1.13.8
           import: github.com/buildkite/agent
           environment:
             - GOOS=darwin


### PR DESCRIPTION
According to https://gist.github.com/asukakenji/f15ba7e588ac42795f421b48b8aede63 android + arm isn't a valid compile target, so this changes it to the more compatible linux + arm.

It also bumps all references to the Golang version while we're here too.